### PR TITLE
feat: API 예외 처리 시스템 추가

### DIFF
--- a/src/main/java/likelion/festival/exception/ApiError.java
+++ b/src/main/java/likelion/festival/exception/ApiError.java
@@ -1,0 +1,32 @@
+package likelion.festival.exception;
+
+import lombok.Getter;
+
+@Getter
+public class ApiError {
+    private final String status = "error";
+    private final String code;
+    private final String message;
+    private final String detail;
+
+    public ApiError(String code, String message) {
+        this.code = code;
+        this.message = message;
+        this.detail = null;
+    }
+
+    public ApiError(String code, String message, String detail) {
+        this.code = code;
+        this.message = message;
+        this.detail = detail;
+    }
+
+    public static ApiError of(ErrorCode errorCode) {
+        return new ApiError(errorCode.getCode(), errorCode.getMessage());
+    }
+
+    public static ApiError of(ErrorCode errorCode, String detail) {
+        return new ApiError(errorCode.getCode(), errorCode.getMessage(), detail);
+    }
+}
+

--- a/src/main/java/likelion/festival/exception/ApiException.java
+++ b/src/main/java/likelion/festival/exception/ApiException.java
@@ -1,0 +1,22 @@
+package likelion.festival.exception;
+
+import lombok.Getter;
+
+@Getter
+public class ApiException extends RuntimeException {
+    private final ErrorCode errorCode;
+    private final String detail;
+
+    public ApiException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+        this.detail = null;
+    }
+
+    public ApiException(ErrorCode errorCode, String detail) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+        this.detail = detail;
+    }
+}
+

--- a/src/main/java/likelion/festival/exception/ApiSuccess.java
+++ b/src/main/java/likelion/festival/exception/ApiSuccess.java
@@ -1,0 +1,29 @@
+package likelion.festival.exception;
+
+import lombok.Getter;
+
+@Getter
+public class ApiSuccess<T> {
+    private final String status = "success";
+    private final T data;
+    private final String message;
+
+    public ApiSuccess(T data) {
+        this.data = data;
+        this.message = null;
+    }
+
+    public ApiSuccess(T data, String message) {
+        this.data = data;
+        this.message = message;
+    }
+
+    public static <T> ApiSuccess<T> of(T data) {
+        return new ApiSuccess<>(data);
+    }
+
+    public static <T> ApiSuccess<T> of(T data, String message) {
+        return new ApiSuccess<>(data, message);
+    }
+}
+

--- a/src/main/java/likelion/festival/exception/ErrorCode.java
+++ b/src/main/java/likelion/festival/exception/ErrorCode.java
@@ -1,0 +1,28 @@
+package likelion.festival.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorCode {
+    // 400 Bad Request
+    INVALID_ARGUMENT(HttpStatus.BAD_REQUEST, "E400001", "잘못된 요청 파라미터입니다."),
+    VALIDATION_FAILED(HttpStatus.BAD_REQUEST, "E400002", "유효성 검증에 실패했습니다."),
+
+    // 404 Not Found
+    MENU_NOT_FOUND(HttpStatus.NOT_FOUND, "E404001", "메뉴를 찾을 수 없습니다."),
+    PUB_NOT_FOUND(HttpStatus.NOT_FOUND, "E404002", "주점을 찾을 수 없습니다."),
+    ARTIST_NOT_FOUND(HttpStatus.NOT_FOUND, "E404003", "가수를 찾을 수 없습니다."),
+    PERFORMANCE_NOT_FOUND(HttpStatus.NOT_FOUND, "E404004", "공연을 찾을 수 없습니다."),
+    FORTUNE_NOT_FOUND(HttpStatus.NOT_FOUND, "E404005", "운세를 찾을 수 없습니다."),
+    NOTICE_NOT_FOUND(HttpStatus.NOT_FOUND, "E404006", "공지사항을 찾을 수 없습니다."),
+
+    // 500 Internal Server Error
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "E500001", "서버 내부 오류가 발생했습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/likelion/festival/exception/GlobalExceptionHandler.java
+++ b/src/main/java/likelion/festival/exception/GlobalExceptionHandler.java
@@ -1,0 +1,49 @@
+package likelion.festival.exception;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    // ApiException 처리
+    @ExceptionHandler(ApiException.class)
+    public ResponseEntity<ApiError> handleApiException(ApiException ex) {
+        log.warn("ApiException occurred: {}", ex.getMessage());
+
+        ApiError apiError = ex.getDetail() != null
+                ? ApiError.of(ex.getErrorCode(), ex.getDetail())
+                : ApiError.of(ex.getErrorCode());
+
+        return ResponseEntity
+                .status(ex.getErrorCode().getHttpStatus())
+                .body(apiError);
+    }
+
+    // Validation 예외 처리 (@Valid, @Validated)
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ApiError> handleMethodArgumentNotValid(MethodArgumentNotValidException ex) {
+        log.warn("Validation failed: {}", ex.getMessage());
+
+        String detail = ex.getBindingResult().getFieldErrors().stream()
+                .map(error -> error.getField() + ": " + error.getDefaultMessage())
+                .reduce((a, b) -> a + ", " + b)
+                .orElse("유효성 검증 실패");
+
+        ApiError apiError = ApiError.of(ErrorCode.VALIDATION_FAILED, detail);
+        return ResponseEntity.badRequest().body(apiError);
+    }
+
+    // 일반 예외 처리
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ApiError> handleException(Exception ex) {
+        log.error("Unexpected error occurred", ex);
+
+        ApiError apiError = ApiError.of(ErrorCode.INTERNAL_SERVER_ERROR);
+        return ResponseEntity.internalServerError().body(apiError);
+    }
+}


### PR DESCRIPTION
## Summary
일관된 API 응답 형식 반환을 위한 예외 처리 시스템 추가

## PR Type
- [X] Feature
- [ ] Bugfix
- [ ] Refactoring
- [ ] Code style changes (formatting, variable name, comments)
- [ ] Documentation content changes
- [ ] Test related changes
- [ ] Build related changes
- [ ] Delete or rename a file or folder
- [ ] Other:

## 적용 가이드

### 1. 성공 응답
```java
@GetMapping("/menus")
public ResponseEntity<ApiSuccess<List<Menu>>> getMenus() {
    List<Menu> menus = menuService.findAll();
    return ResponseEntity.ok(ApiSuccess.of(menus, "메뉴 목록 조회 완료"));
}
```

**응답 예시:**
```json
{
  "status": "success",
  "data": [
    {
      "id": 1, 
      "menuName": "김치찌개", 
      "price": 8000
    }
  ],
  "message": "메뉴 목록 조회 완료"
}
```

### 2. 에러 응답
```java
@GetMapping("/menus/{id}")
public ResponseEntity<ApiSuccess<Menu>> getMenu(@PathVariable Long id) {
    Menu menu = menuService.findById(id);
    if (menu == null) {
        throw new ApiException(ErrorCode.MENU_NOT_FOUND, "메뉴 ID: " + id);
    }
    return ResponseEntity.ok(ApiSuccess.of(menu));
}
```

**에러 응답 예시:**
```json
{
  "status": "error",
  "code": "E404001",
  "message": "메뉴를 찾을 수 없습니다.",
  "detail": "메뉴 ID: 999"
}
```

### 지원하는 에러 코드

| HTTP Status | 에러 코드 | 설명 |
|-------------|-----------|------|
| 400 | E400001 | 잘못된 요청 파라미터 |
| 400 | E400002 | 유효성 검증 실패 |
| 404 | E404001 | 메뉴를 찾을 수 없음 |
| 404 | E404002 | 주점을 찾을 수 없음 |
| 404 | E404003 | 가수를 찾을 수 없음 |
| 404 | E404004 | 공연을 찾을 수 없음 |
| 404 | E404005 | 운세를 찾을 수 없음 |
| 404 | E404006 | 공지사항을 찾을 수 없음 |
| 500 | E500001 | 서버 내부 오류 |

### 주의사항

1. **`ErrorCode` enum에 새 에러 추가 시**: HTTP 상태코드도 함께 설정
2. **예외 발생 시**: 적절한 `ErrorCode` 선택 후 `ApiException` 사용