### PR TITLE
feat: 공연, 가수 API 구현

### DIFF
--- a/src/main/java/likelion/festival/controller/ArtistController.java
+++ b/src/main/java/likelion/festival/controller/ArtistController.java
@@ -1,0 +1,31 @@
+package likelion.festival.controller;
+
+import likelion.festival.dto.ArtistResponseDto;
+import likelion.festival.exception.ApiSuccess;
+import likelion.festival.service.ArtistService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 가수 관련 REST API 컨트롤러
+ */
+@RestController
+@RequestMapping("/api/artists")
+@RequiredArgsConstructor
+public class ArtistController {
+
+    private final ArtistService artistService;
+
+    /**
+     * 특정 가수 정보 조회
+     */
+    @GetMapping("/{id}")
+    public ResponseEntity<ApiSuccess<ArtistResponseDto>> getArtistById(@PathVariable Long id) {
+        ArtistResponseDto artist = artistService.getArtistById(id);
+        return ResponseEntity.ok(ApiSuccess.of(artist, "가수 정보 조회 완료"));
+    }
+}

--- a/src/main/java/likelion/festival/controller/PerformanceController.java
+++ b/src/main/java/likelion/festival/controller/PerformanceController.java
@@ -1,0 +1,32 @@
+package likelion.festival.controller;
+
+import likelion.festival.dto.PerformanceResponseDto;
+import likelion.festival.exception.ApiSuccess;
+import likelion.festival.service.PerformanceService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+/**
+ * 공연 관련 REST API 컨트롤러
+ */
+@RestController
+@RequestMapping("/api/performances")
+@RequiredArgsConstructor
+public class PerformanceController {
+
+    private final PerformanceService performanceService;
+
+    /**
+     * 전체 공연 목록 조회
+     */
+    @GetMapping
+    public ResponseEntity<ApiSuccess<List<PerformanceResponseDto>>> getAllPerformances() {
+        List<PerformanceResponseDto> performances = performanceService.getAllPerformances();
+        return ResponseEntity.ok(ApiSuccess.of(performances, "공연 목록 조회 완료"));
+    }
+}

--- a/src/main/java/likelion/festival/domain/Artist.java
+++ b/src/main/java/likelion/festival/domain/Artist.java
@@ -1,0 +1,36 @@
+package likelion.festival.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * 가수 엔티티
+ * 축제 출연 가수 정보를 관리하는 도메인 객체
+ */
+@Getter
+@Entity
+@Table(name = "artists")
+public class Artist {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(length = 50, nullable = false)
+    private String name;
+
+    @Column(length = 50, nullable = false)
+    private String genre;
+
+    @Column(length = 500, nullable = false)
+    private String image;
+
+    @OneToMany(mappedBy = "artist", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    private List<Song> songs = new ArrayList<>();
+
+    @OneToMany(mappedBy = "artist", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    private List<Performance> performances = new ArrayList<>();
+}

--- a/src/main/java/likelion/festival/domain/Performance.java
+++ b/src/main/java/likelion/festival/domain/Performance.java
@@ -1,0 +1,50 @@
+package likelion.festival.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+/**
+ * 공연 엔티티
+ * 축제 공연 정보를 관리하는 도메인 객체
+ */
+@Getter
+@Entity
+@Table(name = "performances")
+public class Performance {
+
+    /**
+     * 공연 일차 열거형
+     */
+    @Getter
+    public enum Day {
+        FIRST("1일차"),
+        SECOND("2일차"),
+        THIRD("3일차");
+
+        private final String value;
+
+        Day(String value) {
+            this.value = value;
+        }
+    }
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Day day;
+
+    @Column(name = "start_time", nullable = false)
+    private LocalDateTime startTime;
+
+    @Column(name = "end_time", nullable = false)
+    private LocalDateTime endTime;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "artist_id", nullable = false)
+    private Artist artist;
+}

--- a/src/main/java/likelion/festival/domain/Song.java
+++ b/src/main/java/likelion/festival/domain/Song.java
@@ -1,0 +1,31 @@
+package likelion.festival.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+
+/**
+ * 대표곡 엔티티
+ * 가수의 대표곡 정보를 관리하는 도메인 객체
+ */
+@Getter
+@Entity
+@Table(name = "songs")
+public class Song {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(length = 50, nullable = false)
+    private String title;
+
+    @Column(length = 500, nullable = false)
+    private String link;
+
+    @Column(length = 500, nullable = false)
+    private String image;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "artist_id", nullable = false)
+    private Artist artist;
+}

--- a/src/main/java/likelion/festival/dto/ArtistResponseDto.java
+++ b/src/main/java/likelion/festival/dto/ArtistResponseDto.java
@@ -1,0 +1,37 @@
+package likelion.festival.dto;
+
+import likelion.festival.domain.Artist;
+
+import java.util.List;
+
+/**
+ * 가수 응답 DTO
+ *
+ * @param id    가수 ID
+ * @param name  이름
+ * @param genre 장르
+ * @param image 프로필 이미지 URL
+ * @param songs 대표곡 목록
+ */
+public record ArtistResponseDto(
+        Long id,
+        String name,
+        String genre,
+        String image,
+        List<SongResponseDto> songs
+) {
+    public static ArtistResponseDto from(Artist artist) {
+        List<SongResponseDto> songs = artist.getSongs()
+                .stream()
+                .map(SongResponseDto::from)
+                .toList();
+
+        return new ArtistResponseDto(
+                artist.getId(),
+                artist.getName(),
+                artist.getGenre(),
+                artist.getImage(),
+                songs
+        );
+    }
+}

--- a/src/main/java/likelion/festival/dto/PerformanceResponseDto.java
+++ b/src/main/java/likelion/festival/dto/PerformanceResponseDto.java
@@ -1,0 +1,34 @@
+package likelion.festival.dto;
+
+import likelion.festival.domain.Performance;
+
+import java.time.format.DateTimeFormatter;
+
+/**
+ * 공연 응답 DTO
+ *
+ * @param id        공연 ID
+ * @param artistId  가수 ID
+ * @param day       공연 일차
+ * @param startTime 시작 시간
+ * @param endTime   종료 시간
+ */
+public record PerformanceResponseDto(
+        Long id,
+        Long artistId,
+        String day,
+        String startTime,
+        String endTime
+) {
+    private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+
+    public static PerformanceResponseDto from(Performance performance) {
+        return new PerformanceResponseDto(
+                performance.getId(),
+                performance.getArtist().getId(),
+                performance.getDay().getValue(),
+                performance.getStartTime().format(FORMATTER),
+                performance.getEndTime().format(FORMATTER)
+        );
+    }
+}

--- a/src/main/java/likelion/festival/dto/SongResponseDto.java
+++ b/src/main/java/likelion/festival/dto/SongResponseDto.java
@@ -1,0 +1,27 @@
+package likelion.festival.dto;
+
+import likelion.festival.domain.Song;
+
+/**
+ * 대표곡 응답 DTO
+ *
+ * @param id    대표곡 ID
+ * @param title 제목
+ * @param link  유튜브 뮤직비디오 URL
+ * @param image 대표곡 이미지 URL
+ */
+public record SongResponseDto(
+        Long id,
+        String title,
+        String link,
+        String image
+) {
+    public static SongResponseDto from(Song song) {
+        return new SongResponseDto(
+                song.getId(),
+                song.getTitle(),
+                song.getLink(),
+                song.getImage()
+        );
+    }
+}

--- a/src/main/java/likelion/festival/repository/ArtistRepository.java
+++ b/src/main/java/likelion/festival/repository/ArtistRepository.java
@@ -1,0 +1,22 @@
+package likelion.festival.repository;
+
+import likelion.festival.domain.Artist;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+/**
+ * 가수 데이터 접근 레포지토리
+ */
+@Repository
+public interface ArtistRepository extends JpaRepository<Artist, Long> {
+
+    /**
+     * 가수 정보와 대표곡을 함께 조회
+     */
+    @Query("SELECT a FROM Artist a LEFT JOIN FETCH a.songs WHERE a.id = :id")
+    Optional<Artist> findByIdWithSongs(@Param("id") Long id);
+}

--- a/src/main/java/likelion/festival/repository/PerformanceRepository.java
+++ b/src/main/java/likelion/festival/repository/PerformanceRepository.java
@@ -1,0 +1,21 @@
+package likelion.festival.repository;
+
+import likelion.festival.domain.Performance;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+/**
+ * 공연 데이터 접근 레포지토리
+ */
+@Repository
+public interface PerformanceRepository extends JpaRepository<Performance, Long> {
+
+    /**
+     * 모든 공연 정보를 가수 정보와 함께 조회
+     */
+    @Query("SELECT p FROM Performance p JOIN FETCH p.artist ORDER BY p.startTime")
+    List<Performance> findAllWithArtist();
+}

--- a/src/main/java/likelion/festival/service/ArtistService.java
+++ b/src/main/java/likelion/festival/service/ArtistService.java
@@ -1,0 +1,30 @@
+package likelion.festival.service;
+
+import likelion.festival.domain.Artist;
+import likelion.festival.dto.ArtistResponseDto;
+import likelion.festival.exception.ApiException;
+import likelion.festival.exception.ErrorCode;
+import likelion.festival.repository.ArtistRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 가수 비즈니스 로직 서비스
+ */
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ArtistService {
+
+    private final ArtistRepository artistRepository;
+
+    /**
+     * 특정 가수 정보 조회
+     */
+    public ArtistResponseDto getArtistById(Long id) {
+        Artist artist = artistRepository.findByIdWithSongs(id)
+                .orElseThrow(() -> new ApiException(ErrorCode.ARTIST_NOT_FOUND, "가수 ID: " + id));
+        return ArtistResponseDto.from(artist);
+    }
+}

--- a/src/main/java/likelion/festival/service/PerformanceService.java
+++ b/src/main/java/likelion/festival/service/PerformanceService.java
@@ -1,0 +1,30 @@
+package likelion.festival.service;
+
+import likelion.festival.dto.PerformanceResponseDto;
+import likelion.festival.repository.PerformanceRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+/**
+ * 공연 비즈니스 로직 서비스
+ */
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class PerformanceService {
+
+    private final PerformanceRepository performanceRepository;
+
+    /**
+     * 전체 공연 목록 조회
+     */
+    public List<PerformanceResponseDto> getAllPerformances() {
+        return performanceRepository.findAllWithArtist()
+                .stream()
+                .map(PerformanceResponseDto::from)
+                .toList();
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -6,6 +6,8 @@ spring:
     name: festival
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
+  jackson:
+    property-naming-strategy: SNAKE_CASE
 
 management:
   endpoints:


### PR DESCRIPTION
## Summary
공연 관련 REST API 구현
- 전체 공연 목록 조회 API (`/api/performances`)
- 특정 가수 정보 및 대표곡 조회 API (`/api/artists/{id}`)
- `JSON` 응답 형식 `snake_case`로 통일

## PR Type
- [x] Feature
- [ ] Bugfix
- [ ] Refactoring
- [ ] Code style changes (formatting, variable name, comments)
- [ ] Documentation content changes
- [ ] Test related changes
- [ ] Build related changes
- [ ] Delete or rename a file or folder
- [ ] Other: