### PR TITLE
fix: 서버 에러코드 추가/이미지 조회 안되는 에러 삭제

### DIFF
--- a/src/main/java/likelion/festival/service/FortuneService.java
+++ b/src/main/java/likelion/festival/service/FortuneService.java
@@ -6,6 +6,8 @@ import likelion.festival.dto.FortuneRequestDto;
 import likelion.festival.dto.FortuneResponseDto;
 import likelion.festival.repository.FortuneRepository;
 import likelion.festival.repository.UserDailyFortuneRepository;
+import likelion.festival.exception.ApiException;
+import likelion.festival.exception.ErrorCode;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -75,7 +77,7 @@ public class FortuneService {
 
         UserDailyFortune saved = userDailyFortuneRepository
                 .findByUserKeyAndFortuneDate(userKey, today)
-                .orElseThrow(() -> new IllegalStateException("Failed to save or retrieve daily fortune."));
+                .orElseThrow(() -> new ApiException(ErrorCode.INTERNAL_SERVER_ERROR));
 
         return fortuneResponse(saved.getFortune());
     }


### PR DESCRIPTION
## Summary
- 운세 이미지가 없음 에러 -> 서버 에러코드로 변경
- +에러 응답 통일
``` json
{
  "status": "error",
  "code": "E500001",
  "message": "서버 내부 오류가 발생했습니다.",
  "detail": "" // Nullable
}
```

## PR Type
- [x] Feature
- [ ] Bugfix
- [ ] Refactoring
- [ ] Code style changes (formatting, variable name, comments)
- [ ] Documentation content changes
- [ ] Test related changes
- [ ] Build related changes
- [ ] Delete or rename a file or folder
- [ ] Other: