### PR TITLE
feat: 유효하지 않은 Endpoint 접근 처리 추가

### DIFF
--- a/src/main/java/likelion/festival/exception/ErrorCode.java
+++ b/src/main/java/likelion/festival/exception/ErrorCode.java
@@ -12,6 +12,7 @@ public enum ErrorCode {
     VALIDATION_FAILED(HttpStatus.BAD_REQUEST, "E400002", "유효성 검증에 실패했습니다."),
 
     // 404 Not Found
+    ENDPOINT_NOT_FOUND(HttpStatus.NOT_FOUND, "E404000", "존재하지 않는 엔드포인트입니다."),
     MENU_NOT_FOUND(HttpStatus.NOT_FOUND, "E404001", "메뉴를 찾을 수 없습니다."),
     PUB_NOT_FOUND(HttpStatus.NOT_FOUND, "E404002", "주점을 찾을 수 없습니다."),
     ARTIST_NOT_FOUND(HttpStatus.NOT_FOUND, "E404003", "가수를 찾을 수 없습니다."),

--- a/src/main/java/likelion/festival/exception/GlobalExceptionHandler.java
+++ b/src/main/java/likelion/festival/exception/GlobalExceptionHandler.java
@@ -5,6 +5,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.resource.NoResourceFoundException;
 
 @Slf4j
 @RestControllerAdvice
@@ -34,8 +35,25 @@ public class GlobalExceptionHandler {
                 .reduce((a, b) -> a + ", " + b)
                 .orElse("유효성 검증 실패");
 
-        ApiError apiError = ApiError.of(ErrorCode.VALIDATION_FAILED, detail);
-        return ResponseEntity.badRequest().body(apiError);
+        ErrorCode errorCode = ErrorCode.VALIDATION_FAILED;
+        ApiError apiError = ApiError.of(errorCode, detail);
+
+        return ResponseEntity
+                .status(errorCode.getHttpStatus())
+                .body(apiError);
+    }
+
+    // 잘못된 URL 경로 요청 처리
+    @ExceptionHandler(NoResourceFoundException.class)
+    public ResponseEntity<ApiError> handleNoResourceFound(NoResourceFoundException ex) {
+        log.warn("Request to non-existent endpoint: {} {}", ex.getHttpMethod(), ex.getResourcePath());
+
+        ErrorCode errorCode = ErrorCode.ENDPOINT_NOT_FOUND;
+        ApiError apiError = ApiError.of(errorCode);
+
+        return ResponseEntity
+                .status(errorCode.getHttpStatus())
+                .body(apiError);
     }
 
     // 일반 예외 처리
@@ -43,7 +61,11 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ApiError> handleException(Exception ex) {
         log.error("Unexpected error occurred", ex);
 
-        ApiError apiError = ApiError.of(ErrorCode.INTERNAL_SERVER_ERROR);
-        return ResponseEntity.internalServerError().body(apiError);
+        ErrorCode errorCode = ErrorCode.INTERNAL_SERVER_ERROR;
+        ApiError apiError = ApiError.of(errorCode);
+
+        return ResponseEntity
+                .status(errorCode.getHttpStatus())
+                .body(apiError);
     }
 }


### PR DESCRIPTION
## Summary
- **잘못된 endpoint 접근에 대한 오류 처리를 추가합니다.**
  - 루트 경로 `/`
  - 브라우저 접속 시 `/favicon.ico`
  - Postman 혹은 FE 측 오타
- **응답 형식**
```json
{
  "status": "error",
  "code": "E404000",
  "message": "존재하지 않는 엔드포인트입니다.",
  "detail": null
}
```

## PR Type
- [x] Feature
- [ ] Bugfix
- [ ] Refactoring
- [ ] Code style changes (formatting, variable name, comments)
- [ ] Documentation content changes
- [ ] Test related changes
- [ ] Build related changes
- [ ] Delete or rename a file or folder
- [ ] Other: