### PR TITLE
Feature/caching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@ build/
 !**/src/main/**/build/
 !**/src/test/**/build/
 
+### k6 script ###
+/k6/
+
 ### ENV ###
 .env
 

--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,10 @@ dependencies {
 
     // Actuator
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
+
+    // cache
+    implementation 'org.springframework.boot:spring-boot-starter-cache'
+    implementation 'com.github.ben-manes.caffeine:caffeine'
 }
 
 tasks.named('test') {

--- a/src/main/java/likelion/festival/FestivalApplication.java
+++ b/src/main/java/likelion/festival/FestivalApplication.java
@@ -2,7 +2,9 @@ package likelion.festival;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cache.annotation.EnableCaching;
 
+@EnableCaching
 @SpringBootApplication
 public class FestivalApplication {
 

--- a/src/main/java/likelion/festival/config/CacheConfig.java
+++ b/src/main/java/likelion/festival/config/CacheConfig.java
@@ -1,0 +1,40 @@
+package likelion.festival.config;
+
+import com.github.benmanes.caffeine.cache.Caffeine;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.caffeine.CaffeineCache;
+import org.springframework.cache.support.SimpleCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.time.Duration;
+import java.util.List;
+
+@Configuration
+public class CacheConfig {
+
+    @Bean
+    public CacheManager cacheManager() {
+        var markers = new CaffeineCache(
+                "markers",
+                Caffeine.newBuilder()
+                        .expireAfterWrite(Duration.ofHours(1))
+                        .maximumSize(100)
+                        .recordStats()
+                        .build()
+        );
+
+        var notices = new CaffeineCache(
+                "notices",
+                Caffeine.newBuilder()
+                        .expireAfterWrite(Duration.ofHours(12))
+                        .maximumSize(100)
+                        .recordStats()
+                        .build()
+        );
+
+        var mgr = new SimpleCacheManager();
+        mgr.setCaches(List.of(markers, notices));
+        return mgr;
+    }
+}

--- a/src/main/java/likelion/festival/service/MarkerService.java
+++ b/src/main/java/likelion/festival/service/MarkerService.java
@@ -3,6 +3,7 @@ package likelion.festival.service;
 import likelion.festival.dto.MarkerResponseDto;
 import likelion.festival.repository.MarkerRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -21,6 +22,7 @@ public class MarkerService {
     /**
      * 전체 마커 목록 조회
      */
+    @Cacheable("markers")
     public List<MarkerResponseDto> getAllMarkers() {
         return markerRepository.findAllWithJoins()
                 .stream()

--- a/src/main/java/likelion/festival/service/NoticeService.java
+++ b/src/main/java/likelion/festival/service/NoticeService.java
@@ -7,6 +7,7 @@ import likelion.festival.exception.ApiException;
 import likelion.festival.exception.ErrorCode;
 import likelion.festival.repository.NoticeRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -19,6 +20,7 @@ public class NoticeService {
     private final NoticeRepository noticeRepository;
 
     // 공지사항 전체 불러오기
+    @Cacheable("notices")
     public List<NoticeDto> getAll() {
         List<Notice> notices = noticeRepository.findAll();
 
@@ -32,6 +34,7 @@ public class NoticeService {
     }
 
     // 공지사항 한개 불러오기
+    @Cacheable("noticeById")
     public NoticeDto getById(Long id) {
         Notice notice = noticeRepository.findById(id)
                 .orElseThrow(() -> new ApiException(ErrorCode.NOTICE_NOT_FOUND, "id = " + id));


### PR DESCRIPTION
## Summary
- 운세, 이벤트, 공지사항, 마커 등 응답시간 측정
- 마커에서 주점, 이벤트 데이터를 같이 가져오는데 거의 고정데이터
- 마커와 공지사항 의 `getAll()` 을 최초요청 때 캐시에 넣고 사용
- TTL 은 변경해가면서 생각해볼 예정

## PR Type
- [x] Feature
- [ ] Bugfix
- [ ] Refactoring
- [ ] Code style changes (formatting, variable name, comments)
- [ ] Documentation content changes
- [ ] Test related changes
- [ ] Build related changes
- [ ] Delete or rename a file or folder
- [ ] Other:

## Screenshot (optional)
### 공지사항 캐싱 전
<img width="771" height="372" alt="Image" src="https://github.com/user-attachments/assets/886b2387-64d4-4389-be0b-8b0257c6aaae" />

### 공지사항 캐싱 후
<img width="764" height="371" alt="Image" src="https://github.com/user-attachments/assets/faec4862-b8cd-47e5-9298-ecc279a3b4af" />

### 마커 캐싱 전
<img width="773" height="241" alt="Image" src="https://github.com/user-attachments/assets/70396068-a17c-4047-b8ff-3f36b0cedf4c" />

### 마커 캐싱 후
<img width="773" height="238" alt="Image" src="https://github.com/user-attachments/assets/d712d379-abf6-4b4c-92d9-72c1178238bf" />


## Notes (optional)
- 마커 캐싱 후 측정 중에 Max = 200ms인 부분이 아마 최초 요청 때 캐시가 비어있어서 데이터베이스 접근, 데이터 처리 및 캐싱 작업으로 나타나는 현상 같습니다.