### PR TITLE
feat: Pub.type 삭제 및 Menu.category drink -> others

### DIFF
--- a/src/main/java/likelion/festival/domain/Menu.java
+++ b/src/main/java/likelion/festival/domain/Menu.java
@@ -16,7 +16,7 @@ public class Menu {
      * 메뉴 카테고리 열거형
      */
     public enum Category {
-        main, side, drink
+        main, side, others
     }
 
     @Id
@@ -30,7 +30,7 @@ public class Menu {
     @Column(nullable = false)
     private Category category;
 
-    @Column(columnDefinition = "TEXT", nullable = false)
+    @Column(columnDefinition = "TEXT") // category == others인 경우 null
     private String description;
 
     @Column(nullable = false)

--- a/src/main/java/likelion/festival/domain/Pub.java
+++ b/src/main/java/likelion/festival/domain/Pub.java
@@ -29,9 +29,6 @@ public class Pub {
     private Double longitude;
 
     @Column(length = 50, nullable = false)
-    private String type;
-
-    @Column(length = 50, nullable = false)
     private String affiliation;
 
     @Column(length = 50, nullable = false)

--- a/src/main/java/likelion/festival/dto/MenuResponseDto.java
+++ b/src/main/java/likelion/festival/dto/MenuResponseDto.java
@@ -7,7 +7,7 @@ import likelion.festival.domain.Menu;
  *
  * @param id          메뉴 ID
  * @param name        메뉴명
- * @param category    메뉴 카테고리 (main, side, drink)
+ * @param category    메뉴 카테고리 (main, side, others)
  * @param description 메뉴 설명
  * @param price       메뉴 가격
  */
@@ -22,7 +22,7 @@ public record MenuResponseDto(
         return new MenuResponseDto(
                 menu.getId(),
                 menu.getName(),
-                menu.getCategory().name().toLowerCase(),
+                menu.getCategory().name(),
                 menu.getDescription(),
                 menu.getPrice()
         );

--- a/src/main/java/likelion/festival/dto/PubResponseDtos.java
+++ b/src/main/java/likelion/festival/dto/PubResponseDtos.java
@@ -8,7 +8,6 @@ public class PubResponseDtos {
      *
      * @param id           주점 ID
      * @param location     주점 위치
-     * @param type         주점 종류
      * @param affiliation  소속 단체
      * @param name         주점명
      * @param takeout      포장 가능 여부
@@ -18,7 +17,6 @@ public class PubResponseDtos {
     public record PubSummaryDto(
             Long id,
             String location,
-            String type,
             String affiliation,
             String name,
             Boolean takeout,
@@ -29,7 +27,6 @@ public class PubResponseDtos {
             return new PubSummaryDto(
                     pub.getId(),
                     pub.getLocation(),
-                    pub.getType(),
                     pub.getAffiliation(),
                     pub.getName(),
                     pub.getTakeout(),
@@ -46,7 +43,6 @@ public class PubResponseDtos {
      * @param location     주점 위치
      * @param latitude     위도
      * @param longitude    경도
-     * @param type         주점 종류
      * @param affiliation  소속 단체
      * @param name         주점명
      * @param takeout      포장 가능 여부
@@ -58,7 +54,6 @@ public class PubResponseDtos {
             String location,
             Double latitude,
             Double longitude,
-            String type,
             String affiliation,
             String name,
             Boolean takeout,
@@ -71,7 +66,6 @@ public class PubResponseDtos {
                     pub.getLocation(),
                     pub.getLatitude(),
                     pub.getLongitude(),
-                    pub.getType(),
                     pub.getAffiliation(),
                     pub.getName(),
                     pub.getTakeout(),


### PR DESCRIPTION
## Summary
- `Pub.type` 속성이 사용하지 않게 되어 삭제
- `Menu.category` 네이밍을 `drink` -> `others` 로 변경 (이 때 `description = null`)
- `Entity` 변경이 있습니다. `ddl-auto: create` 필요 (해결)

## PR Type
- [x] Feature
- [ ] Bugfix
- [ ] Refactoring
- [ ] Code style changes (formatting, variable name, comments)
- [ ] Documentation content changes
- [ ] Test related changes
- [ ] Build related changes
- [ ] Delete or rename a file or folder
- [ ] Other: