### PR TITLE
fix: 학생 공연 정보 revert

### DIFF
--- a/src/main/java/likelion/festival/domain/Performance.java
+++ b/src/main/java/likelion/festival/domain/Performance.java
@@ -43,6 +43,6 @@ public class Performance {
     private LocalDateTime endTime;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "artist_id") // 학생 공연의 경우 null
+    @JoinColumn(name = "artist_id", nullable = false)
     private Artist artist;
 }

--- a/src/main/java/likelion/festival/dto/PerformanceResponseDto.java
+++ b/src/main/java/likelion/festival/dto/PerformanceResponseDto.java
@@ -25,7 +25,7 @@ public record PerformanceResponseDto(
     public static PerformanceResponseDto from(Performance performance) {
         return new PerformanceResponseDto(
                 performance.getId(),
-                performance.getArtist() == null ? null : performance.getArtist().getId(),
+                performance.getArtist().getId(),
                 performance.getDay().getValue(),
                 performance.getStartTime().format(FORMATTER),
                 performance.getEndTime().format(FORMATTER)

--- a/src/main/java/likelion/festival/repository/PerformanceRepository.java
+++ b/src/main/java/likelion/festival/repository/PerformanceRepository.java
@@ -14,8 +14,8 @@ import java.util.List;
 public interface PerformanceRepository extends JpaRepository<Performance, Long> {
 
     /**
-     * 모든 공연 정보를 가수 정보와 함께 조회 (학생 공연은 가수 정보가 null)
+     * 모든 공연 정보를 가수 정보와 함께 조회
      */
-    @Query("SELECT p FROM Performance p LEFT JOIN FETCH p.artist ORDER BY p.startTime")
+    @Query("SELECT p FROM Performance p JOIN FETCH p.artist ORDER BY p.startTime")
     List<Performance> findAllWithArtist();
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -70,7 +70,7 @@ spring:
         format_sql: false
       hibernate.jdbc.time_zone: Asia/Seoul
     hibernate:
-      ddl-auto: create
+      ddl-auto: validate
 
 logging:
   level:


### PR DESCRIPTION
## Summary
- 타임테이블 정보는 FE 측에서 하드코딩 하기로 결정, `nullable` 코드 `revert`

## PR Type
- [ ] Feature
- [x] Bugfix
- [ ] Refactoring
- [ ] Code style changes (formatting, variable name, comments)
- [ ] Documentation content changes
- [ ] Test related changes
- [ ] Build related changes
- [ ] Delete or rename a file or folder
- [ ] Other: