### PR TITLE
fix: 마커 Lazy init 문제 해결 및 Cache Control 헤더 추가

### DIFF
--- a/src/main/java/likelion/festival/controller/MarkerController.java
+++ b/src/main/java/likelion/festival/controller/MarkerController.java
@@ -4,12 +4,14 @@ import likelion.festival.dto.MarkerResponseDto;
 import likelion.festival.exception.ApiSuccess;
 import likelion.festival.service.MarkerService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.CacheControl;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 /**
  * 마커 관련 REST API 컨트롤러
@@ -27,8 +29,10 @@ public class MarkerController {
     @GetMapping
     public ResponseEntity<ApiSuccess<List<MarkerResponseDto>>> getAllMarkers() {
         List<MarkerResponseDto> markers = markerService.getAllMarkers();
-        return ResponseEntity.ok(ApiSuccess.of(markers, "마커 목록 조회 완료"));
-    }
 
+        return ResponseEntity.ok()
+                .cacheControl(CacheControl.maxAge(30, TimeUnit.MINUTES))
+                .body(ApiSuccess.of(markers, "마커 목록 조회 완료"));
+    }
 }
 

--- a/src/main/java/likelion/festival/repository/MarkerRepository.java
+++ b/src/main/java/likelion/festival/repository/MarkerRepository.java
@@ -17,6 +17,7 @@ public interface MarkerRepository extends JpaRepository<Marker, Long> {
      * 모든 마커 정보를 연관된 엔티티와 함께 조회
      */
     @Query("SELECT m FROM Marker m " +
+            "LEFT JOIN FETCH m.closedDays " +
             "LEFT JOIN FETCH m.content c " +
             "LEFT JOIN FETCH c.notice " +
             "LEFT JOIN FETCH m.pub " +


### PR DESCRIPTION
## Summary
- `GET /api/markers` 의 `500` 에러: `closedDays`의 Lazy init으로 인한 세션 불일치 문제로 확인
- 이를 해결하기 위해 `Join fetch` 추가
- `Cache Control` 헤더 추가를 통해 클라이언트 측 캐시 추가

## PR Type
- [x] Feature
- [x] Bugfix
- [ ] Refactoring
- [ ] Code style changes (formatting, variable name, comments)
- [ ] Documentation content changes
- [ ] Test related changes
- [ ] Build related changes
- [ ] Delete or rename a file or folder
- [ ] Other: